### PR TITLE
fix: blind spot in classifications where candidates without codes get…

### DIFF
--- a/app/api/openai/get-best-classification-progression/route.ts
+++ b/app/api/openai/get-best-classification-progression/route.ts
@@ -293,9 +293,10 @@ const getBestClassificationProgressionPremium = async (
         role: "system",
         content: `You are a United States Harmonized Tariff Schedule Expert.
         Your job is to select which candidate best matches the Item Description when appended to the end of the Selection Path.
-        You will be provided with the Item Description, a list of Candidates, a set of Legal Notes, and the current Selection Path to do this.
+        You will be provided with the Item Description, a list of Candidates, a set of Legal Notes, and the current Selection Path to do this task.
         The Selection Path contains the HTS parent elements selected prior to this level. If not provided, this is the first level (heading level).
-        All candidates are valid candidates for the given level, NEVER disregard a candidate just because it doesn't a "code".
+        NEVER dismiss a candidate just because it doesn't have a "code", every candidate should be equally considered for best match.
+        NEVER dismiss a candidate that has a similar title to an item already selected in the Selection Path, it might be the right one.
         
         You MUST follow these exact steps to find best candidate:
         1. Analyze each candidate one by one to determine how well it matches the Item Description when appended to the end of the Selection Path.


### PR DESCRIPTION
… easily dismissed and also candidates with a similar name to a parent do not progress the classification. Often these are the better choice, and the system was ignoring them